### PR TITLE
Play 3.0.0, blocking-slick 0.0.14, scala 2.13.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,16 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.3"
+scalaVersion := "2.13.12"
 
 libraryDependencies ++= Seq(
   guice,
-  "com.github.takezoe" %% "blocking-slick-32" % "0.0.10",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.0" % Test,
+  "com.github.takezoe" %% "blocking-slick" % "0.0.14",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test,
   "com.h2database" % "h2" % "1.4.192",
-  "com.typesafe.play" %% "play-slick" % "3.0.0"
+  "com.typesafe.play" %% "play-slick" % "5.1.0"
+)
+
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,6 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
+
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)


### PR DESCRIPTION
I would be interested to use blocking-slick with the latest play-slick version. 

As a first step, in this PR this repo is updated to use Play 3.0.0, blocking-slick 0.0.14, play-slick 5.1.0, scala 2.13.13. 

The next step would then be to try to upgrade to play-slick 6.1.0 and finally to Scala 3.

As it is, the code compiles fine. I could not run the included tests because I am missing the DDL for the database tables. 